### PR TITLE
Simplify Build targets for plugins build and publish

### DIFF
--- a/src/Pixel.Identity.Provider/Dockerfile
+++ b/src/Pixel.Identity.Provider/Dockerfile
@@ -31,7 +31,6 @@ RUN dotnet restore "src/Pixel.Identity.Store.PostgreSQL/Pixel.Identity.Store.Pos
 
 COPY . .
 WORKDIR "/src/src/Pixel.Identity.Provider"
-RUN dotnet build "Pixel.Identity.Provider.csproj" -c Release -o /app/build
 
 FROM build AS publish
 RUN dotnet publish "Pixel.Identity.Provider.csproj" -c Release -o /app/publish

--- a/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
+++ b/src/Pixel.Identity.Provider/Pixel.Identity.Provider.csproj
@@ -31,21 +31,12 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\Pixel.Identity.Core\Pixel.Identity.Core.csproj" />
-		<ProjectReference Include="..\Pixel.Identity.Messenger.Email\Pixel.Identity.Messenger.Email.csproj" />
 		<ProjectReference Include="..\Pixel.Identity.Shared\Pixel.Identity.Shared.csproj" />
 		<ProjectReference Include="..\Pixel.Identity.UI.Client\Pixel.Identity.UI.Client.csproj" />
 	</ItemGroup>	
 	
-	<Target Name="CopyPluginsOnPublish" AfterTargets="Publish">	
-		<ItemGroup>           
-            <PluginFiles Include="$(TargetDir)\Plugins\**\*.*" />
-        </ItemGroup>
-		<!--<Message Importance="high" Text="Copy Plguins directory from $(TargetDir)\Plugins to $(PublishDir)" />-->
-		<MakeDir Directories="$(PublishDir)\Plugins" />
-		<Copy SourceFiles="@(PluginFiles)" DestinationFiles="@(PluginFiles -> '$(PublishDir)Plugins\%(RecursiveDir)%(Filename)%(Extension)')" />
-	</Target>
-	
-	<Target Name="PublishPluginsOnBuild" BeforeTargets="Build">
+	<!--Build the plugins project with their outputpath set to $(TargetDir)\Plugins\....-->
+	<Target Name="BuildPlugins" AfterTargets="Build">
 		<ItemGroup>
 			<DbStorePluginProject Include="..\Pixel.Identity.Store.Mongo\Pixel.Identity.Store.Mongo.csproj" />
 			<DbStorePluginProject Include="..\Pixel.Identity.Store.SqlServer\Pixel.Identity.Store.SqlServer.csproj" />
@@ -54,10 +45,18 @@
 		<ItemGroup>
 			<MessengerPluginProject Include="..\Pixel.Identity.Messenger.Email\Pixel.Identity.Messenger.Email.csproj" />
 			<MessengerPluginProject Include="..\Pixel.Identity.Messenger.Console\Pixel.Identity.Messenger.Console.csproj" />
-		</ItemGroup>
-		<!--<Message Importance="high" Text="Executing build plugins now with PublishDir $(TargetDir)Plugins" />-->	
-		<MSBuild Projects="@(DbStorePluginProject)" Targets="Publish" Properties="PublishDir=$(TargetDir)Plugins\DbStore\%(FileName)\" />
-		<MSBuild Projects="@(MessengerPluginProject)" Targets="Publish" Properties="PublishDir=$(TargetDir)Plugins\Messenger\%(FileName)\" />
+		</ItemGroup>		
+		<MSBuild RebaseOutputs="true" Projects="@(DbStorePluginProject)" Targets="Build" Properties="OutputPath=$(TargetDir)Plugins\DbStore\%(FileName)\" />
+		<MSBuild RebaseOutputs="true" Projects="@(MessengerPluginProject)" Targets="Build" Properties="OutputPath=$(TargetDir)Plugins\Messenger\%(FileName)\" />
 	</Target>
 
+	<!--On publish add additional step to copy the plugins folder from build\plugins to publish\plugins-->
+	<Target Name="CopyPluginsOnPublish" AfterTargets="Publish">
+		<ItemGroup>
+			<PluginFiles Include="$(TargetDir)\Plugins\**\*.*" />
+		</ItemGroup>		
+		<MakeDir Directories="$(PublishDir)\Plugins" />
+		<Copy SourceFiles="@(PluginFiles)" DestinationFiles="@(PluginFiles -> '$(PublishDir)Plugins\%(RecursiveDir)%(Filename)%(Extension)')" />
+	</Target>
+	
 </Project>


### PR DESCRIPTION
**Description**
Build targets for build and publish of plugins were confusing to understand. Simplified them to better understand what happens on build vs publish along with some comments. Additionally, the dotnet build command in dockerfile is not required as dotnet publish will do a build as well.