### PR TITLE
Fix failing test cases in headless mode

### DIFF
--- a/src/Pixel.Identity.UI.Tests/PageModels/AddRolePage.cs
+++ b/src/Pixel.Identity.UI.Tests/PageModels/AddRolePage.cs
@@ -51,7 +51,17 @@ internal class AddRolePage
         }, new PageRunAndWaitForNavigationOptions()
         {
             UrlRegex = new System.Text.RegularExpressions.Regex(".*/roles/list")
+        });      
+        //wait for the snackbar to show up
+        await this.page.Locator("div.mud-snackbar").WaitForAsync(new LocatorWaitForOptions()
+        {
+            Timeout = 5000
         });
-        await this.page.ClickAsync("div.mud-snackbar.mud-alert-filled-success button");
+        await this.page.Locator("div.mud-snackbar.mud-alert-filled-success button").ClickAsync();
+        await this.page.WaitForSelectorAsync("div.mud-snackbar.mud-alert-filled-success",new PageWaitForSelectorOptions()
+        {
+             State = WaitForSelectorState.Detached,
+             Timeout = 5000
+        });
     }
 }


### PR DESCRIPTION
**Description**
In headless mode, test cases are failing. While creating a new role , a success dialog pops up. The test code closes this dialog . However, the next tests seems to start to quickly before this dialog is  detached from DOM. This causes next test to end up finding more than one dialog causing tests to fail. 