### PR TITLE
reuse-workflows-for-publish-to-docker-hub

### DIFF
--- a/.github/workflows/identity-build-and-test-docker.yaml
+++ b/.github/workflows/identity-build-and-test-docker.yaml
@@ -2,123 +2,24 @@ name: Identity build and test with docker image
 
 on:
   workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+     - 'src/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+     - 'src/**'
 
 jobs:
 
   build-docker-image:
-   runs-on: ubuntu-latest  
-   steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3   
-    - name: Build docker image locally
-      uses: docker/build-push-action@v2
-      with:
-          context: ./
-          file: ./src/Pixel.Identity.Provider/Dockerfile        
-          push: false
-          tags: pixel-identity:latest
-          load: true
-    - name: Upload docker image as artifcat
-      uses: ishworkh/docker-image-artifact-upload@v1
-      with:
-        image: "pixel-identity:latest"
+    uses: ./.github/workflows/identity-build-docker-image.yaml
   
   test-with-postgres-db:
-   needs: build-docker-image
-   runs-on: ubuntu-latest
-   strategy:
-      matrix:
-        dotnet-version: [ '6.0.x' ]
-
-   services:
-     postgres:
-        image: postgres:latest
-        env:
-          POSTGRES_USER: postgresadmin
-          POSTGRES_PASSWORD: postgrespass
-          POSTGRES_DB: pixel_identity_db
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-          
-   steps:  
-     - name: Checkout Repository
-       uses: actions/checkout@v3   
-     - name: Download docker image
-       uses: ishworkh/docker-image-artifact-download@v1
-       with:
-        image: "pixel-identity:latest"
-     - name: Launch docker image
-       run: >
-         docker run -d -p 44382:80 --network=${{ job.container.network }}
-         -e AllowedOrigins=http://localhost:44382 -e IdentityHost=http://localhost:44382/pauth
-         --env-file ./.config/identity-postgres-with-console-email.env
-         --name pixel_identity_provider pixel-identity:latest     
-     - name: Print container details
-       run: docker container ls     
-     - name: Setup dotnet ${{ matrix.dotnet-version }}
-       uses: actions/setup-dotnet@v2
-       with:
-        dotnet-version: ${{ matrix.dotnet-version }}    
-     - name: Build test project     
-       run: dotnet build src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
-     - name: print container logs
-       run: docker logs pixel_identity_provider
-     - name: Install browsers
-       run: pwsh src/Pixel.Identity.UI.Tests/bin/Debug/net6.0/playwright.ps1 install
-     - name:  Execute tests
-       run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
-     - name: Upload test results
-       uses: actions/upload-artifact@v3
-       with:
-        name: pixel-identity-postgres-automation-test-results-${{ matrix.os }}
-        path: src/Pixel.Identity.UI.Tests/TestResults  
+    needs: build-docker-image
+    uses: ./.github/workflows/identity-test-docker-image-with-postgres.yaml           
 
   test-with-mongo-db:
    needs: build-docker-image
-   runs-on: ubuntu-latest
-   strategy:
-      matrix:
-        dotnet-version: [ '6.0.x' ]
-
-   services:
-     mongo:
-        image: mongo:latest
-        env:
-          MONGO_INITDB_ROOT_USERNAME: mongoadmin
-          MONGO_INITDB_ROOT_PASSWORD: mongopass      
-          
-   steps:  
-     - name: Checkout Repository
-       uses: actions/checkout@v3   
-     - name: Download docker image
-       uses: ishworkh/docker-image-artifact-download@v1
-       with:
-        image: "pixel-identity:latest"
-     - name: Launch docker image
-       run: >
-         docker run -d -p 44382:80 --network=${{ job.container.network }}
-         -e AllowedOrigins=http://localhost:44382 -e IdentityHost=http://localhost:44382/pauth
-         --env-file ./.config/identity-mongo-with-console-email.env
-         --name pixel_identity_provider pixel-identity:latest     
-     - name: Print container details
-       run: docker container ls     
-     - name: Setup dotnet ${{ matrix.dotnet-version }}
-       uses: actions/setup-dotnet@v2
-       with:
-        dotnet-version: ${{ matrix.dotnet-version }}    
-     - name: Build test project     
-       run: dotnet build src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
-     - name: print container logs
-       run: docker logs pixel_identity_provider
-     - name: Install browsers
-       run: pwsh src/Pixel.Identity.UI.Tests/bin/Debug/net6.0/playwright.ps1 install
-     - name:  Execute tests
-       run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
-     - name: Upload test results
-       uses: actions/upload-artifact@v3
-       with:
-        name: pixel-identity-mongo-automation-test-results-${{ matrix.os }}
-        path: src/Pixel.Identity.UI.Tests/TestResults  
+   uses: ./.github/workflows/identity-test-docker-image-with-mongo.yaml    

--- a/.github/workflows/identity-build-docker-image.yaml
+++ b/.github/workflows/identity-build-docker-image.yaml
@@ -1,0 +1,29 @@
+name: Build docker image and upload as artificat
+
+on: [workflow_call]
+
+jobs:
+
+  build-docker-image:
+   runs-on: ubuntu-latest  
+   steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3  
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+        images: ${{ secrets.DOCKERHUB_USERNAME }}/pixel-identity
+    - name: Build docker image locally
+      uses: docker/build-push-action@v2
+      with:
+          context: ./
+          file: ./src/Pixel.Identity.Provider/Dockerfile        
+          push: false
+          tags: pixel-identity:local
+          labels: ${{ steps.meta.outputs.labels }}
+          load: true
+    - name: Upload docker image as artifcat
+      uses: ishworkh/docker-image-artifact-upload@v1
+      with:
+        image: "pixel-identity:local"

--- a/.github/workflows/identity-publish-to-docker-hub.yaml
+++ b/.github/workflows/identity-publish-to-docker-hub.yaml
@@ -1,0 +1,38 @@
+name: Publish image to docker hub on tag push to main
+
+on:
+  push:
+    branches: [ main ]
+    tags:        
+      - v*
+
+jobs:
+
+  build-docker-image:
+    uses: ./.github/workflows/identity-build-docker-image.yaml
+  
+  test-with-postgres-db:
+    needs: build-docker-image
+    uses: ./.github/workflows/identity-test-docker-image-with-postgres.yaml           
+
+  test-with-mongo-db:
+   needs: build-docker-image
+   uses: ./.github/workflows/identity-test-docker-image-with-mongo.yaml   
+
+  publish-to-docker-hub:
+    needs: [test-with-postgres-db, test-with-mongo-db]
+    runs-on: ubuntu-latest
+    steps:     
+      - name: Download and load docker image
+        uses: ishworkh/docker-image-artifact-download@v1
+        with:
+          image: "pixel-identity:local"  
+      - name: Login to docker hub      
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Tag image 
+        run: docker tag pixel-identity:local ${{ secrets.DOCKERHUB_USERNAME }}/pixel-identity:${{ github.ref_name }}
+      - name: Push image to docker hub
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/pixel-identity:${{ github.ref_name }}

--- a/.github/workflows/identity-test-docker-image-with-mongo.yaml
+++ b/.github/workflows/identity-test-docker-image-with-mongo.yaml
@@ -1,0 +1,51 @@
+name: Identity build and test with docker image
+
+on: [workflow_call]
+
+jobs:  
+ 
+  test-with-mongo-db: 
+   runs-on: ubuntu-latest
+   strategy:
+      matrix:
+        dotnet-version: [ '6.0.x' ]
+
+   services:
+     mongo:
+        image: mongo:latest
+        env:
+          MONGO_INITDB_ROOT_USERNAME: mongoadmin
+          MONGO_INITDB_ROOT_PASSWORD: mongopass      
+          
+   steps:  
+     - name: Checkout Repository
+       uses: actions/checkout@v3   
+     - name: Download and load docker image
+       uses: ishworkh/docker-image-artifact-download@v1
+       with:
+        image: "pixel-identity:local"
+     - name: Launch docker image
+       run: >
+         docker run -d -p 44382:80 --network=${{ job.container.network }}
+         -e AllowedOrigins=http://localhost:44382 -e IdentityHost=http://localhost:44382/pauth
+         --env-file ./.config/identity-mongo-with-console-email.env
+         --name pixel_identity_provider pixel-identity:local     
+     - name: Print container details
+       run: docker container ls     
+     - name: Setup dotnet ${{ matrix.dotnet-version }}
+       uses: actions/setup-dotnet@v2
+       with:
+        dotnet-version: ${{ matrix.dotnet-version }}    
+     - name: Build test project     
+       run: dotnet build src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+     - name: print container logs
+       run: docker logs pixel_identity_provider
+     - name: Install browsers
+       run: pwsh src/Pixel.Identity.UI.Tests/bin/Debug/net6.0/playwright.ps1 install
+     - name:  Execute tests
+       run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+     - name: Upload test results
+       uses: actions/upload-artifact@v3
+       with:
+        name: pixel-identity-mongo-automation-test-results-${{ matrix.os }}
+        path: src/Pixel.Identity.UI.Tests/TestResults  

--- a/.github/workflows/identity-test-docker-image-with-postgres.yaml
+++ b/.github/workflows/identity-test-docker-image-with-postgres.yaml
@@ -1,0 +1,59 @@
+name: Test docker image with postgres backend
+
+on: [workflow_call]
+
+jobs:  
+  
+  test-with-postgres-db: 
+   runs-on: ubuntu-latest
+   strategy:
+      matrix:
+        dotnet-version: [ '6.0.x' ]
+
+   services:
+     postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgresadmin
+          POSTGRES_PASSWORD: postgrespass
+          POSTGRES_DB: pixel_identity_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+          
+   steps:  
+     - name: Checkout Repository
+       uses: actions/checkout@v3   
+     - name: Download and load docker image
+       uses: ishworkh/docker-image-artifact-download@v1
+       with:
+        image: "pixel-identity:local"
+     - name: Launch docker image
+       run: >
+         docker run -d -p 44382:80 --network=${{ job.container.network }}
+         -e AllowedOrigins=http://localhost:44382 -e IdentityHost=http://localhost:44382/pauth
+         --env-file ./.config/identity-postgres-with-console-email.env
+         --name pixel_identity_provider pixel-identity:local     
+     - name: Print container details
+       run: docker container ls     
+     - name: Setup dotnet ${{ matrix.dotnet-version }}
+       uses: actions/setup-dotnet@v2
+       with:
+        dotnet-version: ${{ matrix.dotnet-version }}    
+     - name: Build test project     
+       run: dotnet build src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+     - name: print container logs
+       run: docker logs pixel_identity_provider
+     - name: Install browsers
+       run: pwsh src/Pixel.Identity.UI.Tests/bin/Debug/net6.0/playwright.ps1 install
+     - name:  Execute tests
+       run: dotnet test  --logger "trx;" src/Pixel.Identity.UI.Tests/Pixel.Identity.UI.Tests.csproj
+     - name: Upload test results
+       uses: actions/upload-artifact@v3
+       with:
+        name: pixel-identity-postgres-automation-test-results-${{ matrix.os }}
+        path: src/Pixel.Identity.UI.Tests/TestResults  
+
+   

--- a/Pixel.Identity.sln
+++ b/Pixel.Identity.sln
@@ -43,6 +43,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\identity-build-and-test-docker.yaml = .github\workflows\identity-build-and-test-docker.yaml
 		.github\workflows\identity-build-only.yaml = .github\workflows\identity-build-only.yaml
+		.github\workflows\identity-build-docker-image.yaml = .github\workflows\identity-build-docker-image.yaml
+		.github\workflows\identity-publish-to-docker-hub.yaml = .github\workflows\identity-publish-to-docker-hub.yaml
+		.github\workflows\identity-test-docker-image-with-mongo.yaml = .github\workflows\identity-test-docker-image-with-mongo.yaml
+		.github\workflows\identity-test-docker-image-with-postgres.yaml = .github\workflows\identity-test-docker-image-with-postgres.yaml
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
**Description**
Add a new workflow for publish to docker hub whenever a tag is pushed on main branch . Also, refactored workflow for reuse.