### PR TITLE
Fix secrets not being passed to docker login action

### DIFF
--- a/.github/workflows/identity-publish-to-docker-hub.yaml
+++ b/.github/workflows/identity-publish-to-docker-hub.yaml
@@ -1,8 +1,7 @@
 name: Publish image to docker hub on tag push to main
 
 on:
-  push:
-    branches: [ main ]
+  push:    
     tags:        
       - v*
 
@@ -22,6 +21,7 @@ jobs:
   publish-to-docker-hub:
     needs: [test-with-postgres-db, test-with-mongo-db]
     runs-on: ubuntu-latest
+    environment: docker-hub
     steps:     
       - name: Download and load docker image
         uses: ishworkh/docker-image-artifact-download@v1


### PR DESCRIPTION
**Description**
1. Job should declare environment before it can access declared secrets within those environment. Added docker-hub environment reference for publish-to-docker-hub job.
2. Updated job trigger so that it only starts when a tag is pushed. 